### PR TITLE
Re-include `_headers` & `_redirects`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -110,6 +110,8 @@ plugins:
 include:
   # Folders with dotfiles are ignored by default.
   - .well-known
+  - _headers
+  - _redirects
 exclude:
   - CHANGELOG.md
   - netlify.toml


### PR DESCRIPTION
Turns out they do not work unless included in site directory