### PR TITLE
Update Rollup config & plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "eslint-plugin-frontmatter": "0.0.8",
         "firebase-admin": "^11.8.0",
-        "netlify-js-app": "^3.0.3",
+        "netlify-js-app": "^3.0.4",
         "stripe": "^12.4.0",
         "yaml": "^2.2.2"
       }
@@ -1396,14 +1396,14 @@
       }
     },
     "node_modules/@shgysk8zer0/rollup-import": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/rollup-import/-/rollup-import-0.0.4.tgz",
-      "integrity": "sha512-30AQqm92oB91XxJRaI4cBw4lYFmRH2Tjn3mqEYdvt83HOt2IUqgabcR0gg9vTI65l9w0F0+jPQnusEMk2unNXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@shgysk8zer0/rollup-import/-/rollup-import-1.0.0.tgz",
+      "integrity": "sha512-CejjHIQ0bEduSSzR7+KFc2OpeDYpjV4LRe/s5DzgSUTmw/OaD5MEgHSEaNvRfYVfUA4Bl/TL83Xc91qFDmaI3w==",
       "dependencies": {
         "yaml": "^2.2.2"
       },
       "engines": {
-        "node": ">=18.13.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "rollup": "*"
@@ -19921,13 +19921,13 @@
       }
     },
     "node_modules/netlify-js-app": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/netlify-js-app/-/netlify-js-app-3.0.3.tgz",
-      "integrity": "sha512-nvWQrSF4Km03KgLxRlj42Ks85aOaiNMJdof0h97cifmSjQQeRiDFsr4RJ3Z6aW0AX2QNTJLes8WYFNqC8MgOoA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/netlify-js-app/-/netlify-js-app-3.0.4.tgz",
+      "integrity": "sha512-DLczr+VGd/DBQP39qvX6xNTgJt7djq7BuzsokX8RZBb6nYuWuLaDJoSo6JWgjDSMkiLaIvTa75lpyAYQxBpnqA==",
       "dependencies": {
         "@babel/core": "^7.13.15",
         "@rollup/plugin-terser": "^0.4.1",
-        "@shgysk8zer0/rollup-import": "^0.0.4",
+        "@shgysk8zer0/rollup-import": "^1.0.0",
         "cssnano": "^6.0.0",
         "cssnano-preset-default": "^6.0.0",
         "eslint": "^8.0.1",
@@ -23928,9 +23928,9 @@
       }
     },
     "@shgysk8zer0/rollup-import": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/rollup-import/-/rollup-import-0.0.4.tgz",
-      "integrity": "sha512-30AQqm92oB91XxJRaI4cBw4lYFmRH2Tjn3mqEYdvt83HOt2IUqgabcR0gg9vTI65l9w0F0+jPQnusEMk2unNXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@shgysk8zer0/rollup-import/-/rollup-import-1.0.0.tgz",
+      "integrity": "sha512-CejjHIQ0bEduSSzR7+KFc2OpeDYpjV4LRe/s5DzgSUTmw/OaD5MEgHSEaNvRfYVfUA4Bl/TL83Xc91qFDmaI3w==",
       "requires": {
         "yaml": "^2.2.2"
       }
@@ -37447,13 +37447,13 @@
       }
     },
     "netlify-js-app": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/netlify-js-app/-/netlify-js-app-3.0.3.tgz",
-      "integrity": "sha512-nvWQrSF4Km03KgLxRlj42Ks85aOaiNMJdof0h97cifmSjQQeRiDFsr4RJ3Z6aW0AX2QNTJLes8WYFNqC8MgOoA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/netlify-js-app/-/netlify-js-app-3.0.4.tgz",
+      "integrity": "sha512-DLczr+VGd/DBQP39qvX6xNTgJt7djq7BuzsokX8RZBb6nYuWuLaDJoSo6JWgjDSMkiLaIvTa75lpyAYQxBpnqA==",
       "requires": {
         "@babel/core": "^7.13.15",
         "@rollup/plugin-terser": "^0.4.1",
-        "@shgysk8zer0/rollup-import": "^0.0.4",
+        "@shgysk8zer0/rollup-import": "^1.0.0",
         "cssnano": "^6.0.0",
         "cssnano-preset-default": "^6.0.0",
         "eslint": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "eslint-plugin-frontmatter": "0.0.8",
     "firebase-admin": "^11.8.0",
-    "netlify-js-app": "^3.0.3",
+    "netlify-js-app": "^3.0.4",
     "stripe": "^12.4.0",
     "yaml": "^2.2.2"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,4 @@
 /* eslint-env node */
-import urlResolve from 'rollup-plugin-url-resolve';
 import terser from '@rollup/plugin-terser';
 import { rollupImport } from '@shgysk8zer0/rollup-import';
 
@@ -12,7 +11,6 @@ export default {
 	},
 	plugins: [
 		rollupImport(['_data/importmap.yaml']),
-		urlResolve(),
 		terser(),
 	],
 };


### PR DESCRIPTION
Removes usage of `rollup-plugin-url-resolve`. Now provided by `@shgysk8zer0/rollup-import`.